### PR TITLE
[MAINTENANCE] Update Getting Started tutorial version number in `prep` cmd

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The tool is designed to do pretty much EVERYTHING for you. Do not run isolated `
   - Authorize it for use with [SAML SSO](https://docs.github.com/en/enterprise-cloud@latest/authentication/authenticating-with-saml-single-sign-on/authorizing-a-personal-access-token-for-use-with-saml-single-sign-on).
   - Save that token with `export GITHUB_TOKEN=...`.
 - Run `ge_releaser prep <release_version>` and get your PR approved and merged - [Loom walkthrough]()
-  - Open azure and run the `great_expectations` pipeline fully (this will be automated in the future)
+  - Open Azure and run the `great_expectations` pipeline fully (this will be automated in the future)
 - Run `ge_releaser tag` and wait for the build to finish - [Loom walkthrough]()
 - Run `ge_releaser release` - [Loom walkthrough]()
 
@@ -47,6 +47,7 @@ The tool is designed to do pretty much EVERYTHING for you. Do not run isolated `
 - Create a new branch from `develop` called `release-X.Y.Z`.
   - Command: `git checkout -b release-X.Y.Z`
 - Update the version in `great_expectations/deployment_version`.
+- Update the version in `docs/tutorials/getting_started/tutorial_version_snippet.mdx`.
 - Add a new entry to `docs/changelog.md` and `docs_rtd/changelog.rst`.
   - Ensure that lines are ordered by: `[BREAKING] | [FEATURE] | [BUGFIX] | [DOCS] | [MAINTENANCE]`
   - Ensure that each line has a reference to its corresponding PR.

--- a/ge_releaser/cli.py
+++ b/ge_releaser/cli.py
@@ -27,7 +27,7 @@ def cli(ctx: click.Context) -> None:
     ctx.obj = env
 
 
-@cli.command(name="prep", help="Prepare changelogs, release version, and Getting Started in a PR")
+@cli.command(name="prep", help="Prepare changelogs, release version, and Getting Started version in a PR")
 @click.argument("version_number", type=str, nargs=1, required=False)
 @click.option("--file", "file", type=click.Path(exists=True), required=False)
 @click.pass_obj

--- a/ge_releaser/cli.py
+++ b/ge_releaser/cli.py
@@ -27,7 +27,7 @@ def cli(ctx: click.Context) -> None:
     ctx.obj = env
 
 
-@cli.command(name="prep", help="Prepare changelog/release version PR")
+@cli.command(name="prep", help="Prepare changelogs, release version, and Getting Started in a PR")
 @click.argument("version_number", type=str, nargs=1, required=False)
 @click.option("--file", "file", type=click.Path(exists=True), required=False)
 @click.pass_obj

--- a/ge_releaser/constants.py
+++ b/ge_releaser/constants.py
@@ -5,6 +5,7 @@ DEPLOYMENT_VERSION: str = "great_expectations/deployment_version"
 CHANGELOG_MD: str = "docs/changelog.md"
 CHANGELOG_RST: str = "docs_rtd/changelog.rst"
 TEAMS: str = ".github/teams.yml"
+GETTING_STARTED_VERSION: str = "docs/tutorials/getting_started/tutorial_version_snippet.mdx"
 
 GITHUB_REPO: str = "great-expectations/great_expectations"
 AZURE_BUILDS: str = f"https://dev.azure.com/{GITHUB_REPO}/_build?definitionId=1"


### PR DESCRIPTION
Updates version number in our docs so that Getting Started references the latest release of GE.

Demo: https://www.loom.com/share/b7e5d0dc4ba54b5abcd769f4f35c50cd