### PR TITLE
Update readme with `pipx` install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,15 @@ A CLI tool built to streamline the process of cutting releases each week in the 
 ---
 
 ## Installation
+
+#### Reccomended [method via `pipx`](https://pypa.github.io/pipx/)
+
+```bash
+pipx install git+https://github.com/superconductive/ge_releaser
+```
+
+#### Alternate method
+
 ```bash
 # Preferably run all this in a venv
 git clone git@github.com:superconductive/ge_releaser.git


### PR DESCRIPTION
Currently, this doesn't actually work... but it should. Or more specifically the install works but the tool seems to be missing packages.
Will investigate and fix this before merging.

![image](https://user-images.githubusercontent.com/13108583/184264503-66da931f-8394-4350-b1a0-2a9046d313dd.png)


