### PR TITLE
[BUGFIX] Patch faulty changelog insertion logic

### DIFF
--- a/ge_releaser/changelog.py
+++ b/ge_releaser/changelog.py
@@ -86,6 +86,7 @@ class ChangelogEntry:
         for i, line in enumerate(contents):
             if current_version in line:
                 insertion_point = i - 1
+                break
 
         assert (
             insertion_point > 0


### PR DESCRIPTION
Without using `break`, we continue iterating through the whole file to find where to insert the new changelog entry. This error arose because we had a commit that specifically referenced `0.15.20`, causing the insertion point to be moved down the page.